### PR TITLE
meta data export in CSV

### DIFF
--- a/bin/lxr_relfiles.ml
+++ b/bin/lxr_relfiles.ml
@@ -1,27 +1,33 @@
 (* [@@@warning "-32"] *)
 
 open Elykseer__Lxr
+open Elykseer__Lxr.Configuration
 
 open Elykseer_utils
 
 open Mlcpp_chrono
-(* open Mlcpp_cstdio *)
-(* open Mlcpp_filesystem *)
+
+let def_myid = "1234567890"
 
 let arg_verbose = ref false
 let arg_bm = ref false
 let arg_irmin = ref false
-let arg_fctrl = ref ""
+let arg_files = ref []
+let arg_dbpath = ref (Filename.concat (Filename.get_temp_dir_name ()) "db")
+let arg_myid = ref def_myid
+
+let usage_msg = "lxr_relfiles [-v] [-i myid] [-n nchunks] [-d dbpath] <file1> [<file2>] ..."
 
 let argspec =
   [
     ("-v", Arg.Set arg_verbose, "verbose output");
     ("-b", Arg.Set arg_bm, "benchmark");
     ("-x", Arg.Set arg_irmin, "test irmin");
-    ("-f", Arg.Set_string arg_fctrl, "relation file: file->aid");
+    ("-d", Arg.Set_string arg_dbpath, "sets database path");
+    ("-i", Arg.Set_string arg_myid, "sets own identifier");
   ]
 
-let anon_args_fun _fn = ()
+let anon_args_fun fn = arg_files := fn :: !arg_files
 
 let rec mk_blocks i aid apos fpos =
   match i with
@@ -89,7 +95,7 @@ let benchmark_run cnt =
   Gc.print_stat stdout;
   Lwt.return ()
 
-let example_output () =
+(* let example_output () =
   let config : Configuration.configuration =
     { config_nchunks = Nchunks.from_int 16
     ; path_chunks = "lxr"
@@ -126,7 +132,7 @@ let example_output () =
   let%lwt _ = Relfiles.add fhash1 rel1 rel in
   let%lwt _ = Relfiles.add fhash2 rel2 rel in
   let%lwt _ = Relfiles.close_map rel in
-  Lwt_io.printl "done."
+  Lwt_io.printl "done." *)
 
 
 module Config = struct
@@ -172,23 +178,51 @@ let test_irmin () =
       let+ _ = read_exn t [ "root"; "misc"; "3.txt" ] in
       ()
 
+let output_file_blocks fn relfiles : unit Lwt.t =
+  let%lwt rel = Relfiles.find_v (Elykseer_crypto.Sha3_256.string (fn ^ !arg_myid)) relfiles in
+  match rel with
+  | None -> Lwt.return ()
+  | Some (v,r) ->
+    let fhash = r.rfi.fhash in
+    Lwt_list.iter_s (fun (bs: Elykseer__Lxr.Assembly.blockinformation) ->
+      Lwt_io.printlf "\"%s\",\"%s\",%d,%d,%d,\"%s\",%d,\"%s\""
+        v fhash
+        (Conversion.p2i bs.blockid)
+        (Conversion.n2i bs.blocksize)
+        (Conversion.n2i bs.filepos)
+        bs.blockaid
+        (Conversion.n2i bs.blockapos)
+        bs.bchecksum
+    ) r.rfbs
+
+let output_blocks fns relfiles =
+  let%lwt () = Lwt_io.printl "\"version\",\"fhash\",\"blockid\",\"blocksize\",\"filepos\",\"aid\",\"apos\",\"bchecksum\"" in
+  Lwt_list.iter_s (fun (fn : string) -> output_file_blocks fn relfiles) fns
+
 (* main *)
-let main () = Arg.parse argspec anon_args_fun "lxr_relfiles: vbf";
-  let%lwt () = if !arg_bm
-  then
-    let%lwt () = benchmark_run 1_000 in
-    (* let%lwt () = benchmark_run 100_000 in *)
-    Lwt.return ()
-  else if !arg_verbose
+let main () = Arg.parse argspec anon_args_fun usage_msg;
+  if !arg_bm
     then
-      let%lwt () = example_output () in
+      let%lwt () = benchmark_run 1_000 in
+      (* let%lwt () = benchmark_run 100_000 in *)
       Lwt.return ()
     else if !arg_irmin
-      then
-        test_irmin ()
-      else Lwt.return ()
-  in
-  Lwt_io.printl "all done."
+        then
+          test_irmin ()
+        else if !arg_files != []
+          then 
+            let nchunks = Nchunks.from_int 16 in  (* not needed *)
+            let myid = !arg_myid in
+            let conf : configuration = {
+                            config_nchunks = nchunks;
+                            path_chunks = "lxr";
+                            path_db     = !arg_dbpath;
+                            my_id       = myid;
+                            trace       = Tracer.nullTracer } in
+            let%lwt relfiles = Relfiles.new_map conf in
+            output_blocks !arg_files relfiles
+          else
+            Lwt.return ()
 
 let () = Lwt_main.run (main ())
 

--- a/bin/lxr_relkeys.ml
+++ b/bin/lxr_relkeys.ml
@@ -47,10 +47,9 @@ let output_keys fns relfiles relkeys =
   match li with
   | [] -> Lwt.return_unit
   | _ ->
-    let%lwt () = Lwt_io.printl "\"myid\",\"nchunks\",\"version\",\"aid\",\"key\",\"iv\"" in
+    let%lwt () = Lwt_io.printl "\"nchunks\",\"version\",\"aid\",\"key\",\"iv\"" in
     Lwt_list.iter_s (fun ((aid,(version,ki)) : (string * (string * Assembly.keyinformation))) ->
-                          Lwt_io.printlf "%s,%d,\"%s\",\"%s\",\"%s\",\"%s\""
-                            ki.localid
+                          Lwt_io.printlf "%d,\"%s\",\"%s\",\"%s\",\"%s\""
                             (Conversion.p2i ki.localnchunks)
                             version aid ki.pkey ki.ivec ) li
 

--- a/bin/lxr_relkeys.ml
+++ b/bin/lxr_relkeys.ml
@@ -57,7 +57,7 @@ let output_keys fns relfiles relkeys =
 let main () = Arg.parse argspec anon_args_fun usage_msg;
   if !arg_files != []
     then
-      let nchunks = Nchunks.from_int 16 in
+      let nchunks = Nchunks.from_int 16 in (* not needed *)
       let myid = !arg_myid in
       let conf : configuration = {
                       config_nchunks = nchunks;

--- a/elykseer-utils/relfiles.mli
+++ b/elykseer-utils/relfiles.mli
@@ -12,4 +12,5 @@ type filehash = string
 val new_map : Configuration.configuration -> t Lwt.t
 val add : filehash -> relation -> t -> t Lwt.t
 val find : filehash -> t -> relation option Lwt.t
+val find_v : filehash -> t -> (string * relation) option Lwt.t
 val close_map : t -> unit Lwt.t

--- a/elykseer-utils/relkeys.ml
+++ b/elykseer-utils/relkeys.ml
@@ -88,6 +88,8 @@ let find aid db =
                | None -> None
              end
   | _ -> None
+
+  (** find_v: gets aid -> (version * keyinformation) option *)
 let find_v aid db =
   let fp = repo_path aid in
   let%lwt res = Git_store.get db fp in

--- a/elykseer-utils/relkeys.ml
+++ b/elykseer-utils/relkeys.ml
@@ -33,7 +33,6 @@ let version_obj : Git_store.contents =
 let key2json_v1 (k : Assembly.keyinformation) : Git_store.contents =
   `O [ ("ivec", `String k.ivec)
      ; ("pkey", `String k.pkey)
-     ; ("localid", `String k.localid)
      ; ("localnchunks", `String (string_of_int (Conversion.p2i k.localnchunks))) ]
 let keys2json_v1 (keys : Assembly.keyinformation) : Git_store.contents =
   `O [ "version", version_obj
@@ -58,7 +57,6 @@ let json2keys_v1 version obs : (string * Assembly.keyinformation) option =
   | bs -> Some (version,
     { ivec = Relutils.get_str "ivec" bs
     ; pkey = Relutils.get_str "pkey" bs
-    ; localid = Relutils.get_str "localid" bs
     ; localnchunks = Relutils.get_int "localnchunks" bs |> Conversion.i2p
     })
 

--- a/lxr.ml
+++ b/lxr.ml
@@ -3599,7 +3599,7 @@ module Version =
   (** val build : string **)
 
   let build =
-    "13"
+    "14"
 
   (** val version : string **)
 

--- a/lxr.ml
+++ b/lxr.ml
@@ -1405,6 +1405,8 @@ module Assembly =
   let mkaid c =
     Utilities.rnd256 c.Configuration.my_id
 
+  type snapshot_t = positive
+
   type assemblyinformation = { nchunks : Nchunks.Private.t; aid : aid_t;
                                apos : n }
 
@@ -1423,7 +1425,7 @@ module Assembly =
   let apos a =
     a.apos
 
-  type keyinformation = { ivec : string; pkey : string; localid : string;
+  type keyinformation = { ivec : string; pkey : string;
                           localnchunks : positive }
 
   (** val ivec : keyinformation -> string **)
@@ -1435,11 +1437,6 @@ module Assembly =
 
   let pkey k =
     k.pkey
-
-  (** val localid : keyinformation -> string **)
-
-  let localid k =
-    k.localid
 
   (** val localnchunks : keyinformation -> positive **)
 
@@ -2087,8 +2084,7 @@ module Environment =
         (fun _ ->
         let (a, b) = Assembly.finish a0 e0.cur_buffer in
         let ki = { Assembly.ivec = (cpp_mk_key128 ()); Assembly.pkey =
-          (cpp_mk_key256 ()); Assembly.localid =
-          e0.econfig.Configuration.my_id; Assembly.localnchunks =
+          (cpp_mk_key256 ()); Assembly.localnchunks =
           e0.econfig.Configuration.config_nchunks }
         in
         Tracer.optionalTrace e0.econfig.Configuration.trace

--- a/lxr.mli
+++ b/lxr.mli
@@ -530,6 +530,8 @@ module Assembly :
 
   val mkaid : Configuration.configuration -> aid_t
 
+  type snapshot_t = positive
+
   type assemblyinformation = { nchunks : Nchunks.Private.t; aid : aid_t;
                                apos : n }
 
@@ -539,14 +541,12 @@ module Assembly :
 
   val apos : assemblyinformation -> n
 
-  type keyinformation = { ivec : string; pkey : string; localid : string;
+  type keyinformation = { ivec : string; pkey : string;
                           localnchunks : positive }
 
   val ivec : keyinformation -> string
 
   val pkey : keyinformation -> string
-
-  val localid : keyinformation -> string
 
   val localnchunks : keyinformation -> positive
 

--- a/test/testRelkeys.ml
+++ b/test/testRelkeys.ml
@@ -11,7 +11,7 @@ let mk_rel n rel =
   let keys : Assembly.keyinformation =
       { pkey = string_of_int (12345678901234567 + n)
       ; ivec = "9876543210123456"
-      ; localnchunks=Conversion.i2p 16; localid="4242" } in
+      ; localnchunks=Conversion.i2p 16 } in
   Relkeys.add aid keys rel
 
 let rec prepare_bm cnt rel =
@@ -61,8 +61,8 @@ let example_output _ () =
     ; my_id = "4242"
     ; trace = Tracer.nullTracer } in
   let%lwt rel = Relkeys.new_map config in
-  let k1 : Assembly.keyinformation = {pkey="key0001";ivec="12";localnchunks=Conversion.i2p 16;localid="43424"} in
-  let k2 : Assembly.keyinformation = {pkey="key0002";ivec="12";localnchunks=Conversion.i2p 24;localid="62831"} in
+  let k1 : Assembly.keyinformation = {pkey="key0001";ivec="12";localnchunks=Conversion.i2p 16} in
+  let k2 : Assembly.keyinformation = {pkey="key0002";ivec="12";localnchunks=Conversion.i2p 24} in
   let%lwt _ = Relkeys.add "aid001" k1 rel in
   let%lwt _ = Relkeys.add "aid002" k2 rel in
   Lwt_io.printl "done."

--- a/theories/Assembly.v
+++ b/theories/Assembly.v
@@ -35,6 +35,8 @@ Definition aid_t := string.
 Definition mkaid (c : configuration) : aid_t :=
     Utilities.rnd256 (my_id c).
 
+Definition snapshot_t := positive.
+
 Definition RecordAssemblyInformation := Set.
 Record assemblyinformation : RecordAssemblyInformation :=
     mkassembly
@@ -47,7 +49,6 @@ Record keyinformation : RecordKeyInformation :=
     mkkeyinformation
         { ivec : string
         ; pkey : string
-        ; localid : string
         ; localnchunks : positive
         }.
 

--- a/theories/Environment.v
+++ b/theories/Environment.v
@@ -59,8 +59,7 @@ Module EnvironmentWritable <: ENV.
             let (a,b) := Assembly.finish a0 e0.(cur_buffer AB) in
             let ki := {| pkey := cpp_mk_key256 tt
                        ; ivec := cpp_mk_key128 tt
-                       ; localnchunks := e0.(econfig AB).(Configuration.config_nchunks)
-                       ; localid := e0.(econfig AB).(Configuration.my_id) |} in
+                       ; localnchunks := e0.(econfig AB).(Configuration.config_nchunks) |} in
             optionalTrace e0.(econfig AB).(trace) (Assembly.encrypt a b ki)
             (Tracer.warning) (Some ("failed to encrypt assembly: " ++ a.(aid))%string)
             (fun _ => None)

--- a/theories/Processor.v
+++ b/theories/Processor.v
@@ -113,7 +113,7 @@ Local Program Fixpoint rec_file_backup_inner (tgtfbs : list blockinformation) (t
             (Tracer.info) (None) (* no message for: Some _ *)
             (fun '(nread, b) =>
                     let b' := BufferPlain.from_buffer b in
-                    (* compare *)
+                    (* compare for deduplication 2 *)
                     let found := if (fb.(bchecksum) =? "")
                         then false
                         else
@@ -255,7 +255,6 @@ Program Definition file_backup (find_fchecksum : string -> option string) (find_
         (fun _ => Some this)
         (Tracer.info) None
         (fun _ =>
-            (* deduplication level 2 per block *)
             let curbs := find_fblocks fi.(fhash) in
             let tgtbs := prepare_blocks curbs fi.(fsize) in
             match open_file_backup fi tgtbs with

--- a/theories/Version.v
+++ b/theories/Version.v
@@ -10,7 +10,7 @@ Open Scope string_scope.
 
 Definition major : string := "0".
 Definition minor : string :=     "9".
-Definition build : string :=         "13".
+Definition build : string :=         "14".
 Definition version : string := major ++ "." ++ minor ++ "." ++ build.
 
 End Version.


### PR DESCRIPTION
- CSV formatted export of "fileinformation" and "keys"
- also includes the removal of "localid"